### PR TITLE
Fix GitHub links on Download page

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -24,7 +24,7 @@ title: Download
     <div class="download col container">
         <a class="reference external" href="https://github.com/IronLanguages/main/tree/ipy-2.7-maint">Download IronPython 2.7 Source Code</a>
     </div>
-    <p><a class="reference external" href="http://github.com/ironlanguages/main">Download latest (zip)</a> | <a class="reference external" href="http://github.com/iron-languages/main">Browse Online</a> | <a class="reference external" href="http://github.com/iron-languages/main">Recent Check-ins</a></p>
+    <p><a class="reference external" href="http://github.com/ironlanguages/main">Download latest (zip)</a> | <a class="reference external" href="http://github.com/ironlanguages/main">Browse Online</a> | <a class="reference external" href="http://github.com/ironlanguages/main">Recent Check-ins</a></p>
     <p><a class="reference external" href="http://github.com/ironlanguages/main">Instructions for accessing with Git</a></p>
 </div>
 <div class="section" id="prerequisites">


### PR DESCRIPTION
Remove superfluous dash (ironlanguages not iron-languages)
