### PR TITLE
Latest version was showing 2.7.6 NOT 2.7.7

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ class: home columns
     <h1>Announcements</h1>
     <div class="strip admonition">
         <p class="first admonition-title">December 7, 2016</p>
-        <p><a class="reference external" href="https://github.com/IronLanguages/main/releases/tag/ipy-2.7.7">IronPython 2.7.6</a> is now available!</p>
+        <p><a class="reference external" href="https://github.com/IronLanguages/main/releases/tag/ipy-2.7.7">IronPython 2.7.7</a> is now available!</p>
         <p>This release includes many fixes.
         <p>See <a href="https://github.com/IronLanguages/main/releases/tag/ipy-2.7.7">
         the release announcement</a> for details.


### PR DESCRIPTION
Hi, just noticed this little error on the main [website](http://ironpython.net/)
Latest version was showing 2.7.6 NOT 2.7.7 